### PR TITLE
Let compute_source_path fall through to ActionView::AssetPaths#compute_source_path

### DIFF
--- a/lib/sprockets/helpers/rails_helper.rb
+++ b/lib/sprockets/helpers/rails_helper.rb
@@ -118,11 +118,6 @@ module Sprockets
 
         class AssetNotPrecompiledError < StandardError; end
 
-        # Return the filesystem path for the source
-        def compute_source_path(source, ext)
-          asset_for(source, ext)
-        end
-
         def asset_for(source, ext)
           source = source.to_s
           return nil if is_uri?(source)


### PR DESCRIPTION
`AssetPaths` was taken from Rails 3.1, but the `compute_source_path` in `rails_helper.rb` overrides the method of the same name in the backport. When trying to get the sass-rails gem to work with this backport, it throws CircularDependencyErrors because the replacement `compute_source_path` never goes to disc.
